### PR TITLE
Use env variables for Supabase client configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ npm run build
 ```
 
 ### Variáveis de Ambiente
+As credenciais do Supabase são lidas do arquivo `.env` e **são obrigatórias** para que a aplicação funcione:
 ```env
 VITE_SUPABASE_URL=sua_url_supabase
 VITE_SUPABASE_ANON_KEY=sua_chave_publica

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,21 +1,18 @@
 import { createClient } from '@supabase/supabase-js'
 
-// CONFIGURAÇÕES FORÇADAS - IGNORAR .env.production
-const SUPABASE_URL = 'https://kmcaaqetxtwkdcczdomw.supabase.co'
-const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImttY2FhcWV0eHR3a2RjY3pkb213Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTM5MjU3MDksImV4cCI6MjA2OTUwMTcwOX0.gFcUOoNPESqp2PALV5CYhMceTQ4HVuf-noGn94Fzbwg'
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY
 
-// Verificação de segurança
+// Validação de variáveis de ambiente
 if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
-  console.error('❌ Configurações do Supabase não encontradas!');
-  throw new Error('Configurações do Supabase inválidas');
+  console.error('❌ Variáveis VITE_SUPABASE_URL ou VITE_SUPABASE_ANON_KEY não configuradas')
+  throw new Error('Configurações do Supabase inválidas')
 }
 
-console.log('🔧 Supabase Config FORÇADO (correto):', {
+console.log('🔧 Supabase Config:', {
   url: SUPABASE_URL,
   hasKey: !!SUPABASE_ANON_KEY,
-  keyLength: SUPABASE_ANON_KEY.length,
-  envUrl: import.meta.env.VITE_SUPABASE_URL,
-  envKey: import.meta.env.VITE_SUPABASE_ANON_KEY ? 'Present' : 'Missing'
+  keyLength: SUPABASE_ANON_KEY.length
 })
 
 export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {


### PR DESCRIPTION
## Summary
- load Supabase credentials from `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`
- validate required Supabase env vars
- document required Supabase env vars in README

## Testing
- `npm run lint` *(fails: Unexpected any)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b10051bea48330ae6feedfeead0fdb